### PR TITLE
Creating 'minimized' widget, enabling rockstar to be available, but o…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,6 @@
       "js": ["jquery-1.12.4.min.PATCHED.js", "rockstar.js"],
       "css": ["rockstar.css"]
     }
-  ]
+  ],
+  "web_accessible_resources": ["rockstar_icon_128.png"]
 }

--- a/rockstar.css
+++ b/rockstar.css
@@ -28,3 +28,19 @@
 .hoverDiv:hover {
     background-color: #f0f0f0;
 }
+.hidden {
+    display: none;
+}
+.widgetButton {
+    background-image: url('chrome-extension://__MSG_@@extension_id__/rockstar_icon_128.png');
+    background-size: 64px 64px;
+    border-radius: 50%;
+    position: absolute;
+    z-index: 1000;
+    bottom: 80px;
+    height: 64px;
+    width: 64px;
+    border: 2px solid black;
+    margin-left: 20px;
+    cursor: context-menu;
+}

--- a/rockstar.js
+++ b/rockstar.js
@@ -1188,13 +1188,15 @@
         function toggleSide() {
             popup.toggleClass('rs_toggle');
         }
-        const popup = $(`<div style='position: absolute; z-index: 1000; top: 0px; max-height: calc(100% - 28px); max-width: calc(100% - 28px); padding: 8px; margin: 4px; overflow: auto; ` +
+
+        const popup = $(`<div id="rockstartPopup" class="hidden" style='position: absolute; z-index: 1000; top: 0px; max-height: calc(100% - 28px); max-width: calc(100% - 28px); padding: 8px; margin: 4px; overflow: auto; ` +
                 `background-color: white; border: 1px solid #ddd;'>` +
                 `${main ? "<span class=title><span style='font-size: 18px;'>≡</span> " : "<span style='font-weight: bold'>"}${title}</span>` +
                 `<div style='display: block; float: right;'>${main ? "<span class=toggleSide style='padding: 4px'> ⇄ </span><span class=minimize style='padding: 4px'> _ </span>" : ""} ` + 
                 `<a href='https://gabrielsroka.github.io/rockstar/' target='_blank' rel='noopener' style='font-size: 18px; padding: 4px'>?</a> ` + 
                 `<a onclick='document.body.removeChild(this.parentNode.parentNode)' style='font-size: 18px; cursor: pointer; padding: 4px'>X</a></div><br><br></div>`)
             .appendTo(document.body);
+        const widgetToggle = $(`<div id="rockstarWidgetToggle" class="widgetButton">`).click(revealPopup).appendTo(document.body);
         const popupBody = $("<div></div>").appendTo(popup);
         if (main) {
             popup.find('.title').click(toggleClosed);
@@ -1210,6 +1212,13 @@
             if (localStorage.rockstarToggleSide) toggleSide();
         }
         return popupBody;
+    }
+    function revealPopup() {
+        var rspopup = document.getElementById('rockstartPopup');
+        var rswidgtoggle = document.getElementById('rockstarWidgetToggle');
+
+        rspopup.classList.remove("hidden");
+        rswidgtoggle.classList.add("hidden");
     }
     function createA(html, parent, clickHandler) {
         createPrefixA("", html, parent, clickHandler);


### PR DESCRIPTION
Creating 'minimized' widget, enabling rockstar to be available, but out of the way

Hi @gabrielsroka --

I started using Okta in September, and your chrome extension has been **a life saver**, but I find myself turning the extension on and off because it feels like it is too often in the way of Okta menus. 
I made a few small updates so that okta pages load with a "minimzed" button on the page that, when clicked, opens up your fantastic extension.

A few disclaimers:

- I'm not a great front-end developer! My background is more in java (Salesforce dev here), so I may not have followed best practices perfectly. Let me know if there are any changes you'd like me to incorporate.
- This is my first time working on a Chrome extension! I think I did enough Google-kung-fu to do things correctly, but I'm not sure if anything needs to be updated for publishing to the chrome web store (manifest version, for example?)